### PR TITLE
Changed onPresenceChanged output from datetime to default (seconds)

### DIFF
--- a/yowsup/demos/cli/layer.py
+++ b/yowsup/demos/cli/layer.py
@@ -453,13 +453,8 @@ class YowsupCliLayer(Cli, YowInterfaceLayer):
     def onPresenceChange(self, entity):
         status="offline"
         if entity.getType() is None:
-            status="online"
-            
-        ltime,formattedDate=entity.getLast(),"none"
-        if ltime is not None:   
-            formattedDate = datetime.datetime.fromtimestamp(float(ltime)).strftime('%d-%m-%Y %H:%M.%S')
-            
-        self.output("%s %s - lastseen %s - from %s" % (entity.getTag(), status, formattedDate, entity.getFrom()))
+            status="online"            
+        self.output("%s %s %s lastseen %s seconds ago" % (entity.getFrom(), entity.getTag(), status, entity.getLast()))
         
     @ProtocolEntityCallback("chatstate")
     def onChatstate(self, entity):


### PR DESCRIPTION
the onPresenceChanged method now output lastseen in seconds that can be converted correctly in a date timestamp with *datetime* class 